### PR TITLE
install: deprecate jammy and add version control

### DIFF
--- a/content/support.md
+++ b/content/support.md
@@ -1,0 +1,14 @@
+---
+title: "Support"
+draft: false
+---
+
+Questions are welcome on our IRC channel (`#ubuntu-asahi` on OFTC) and [Fediverse account](https://social.treehouse.systems/@ubuntuasahi).
+
+Issues in Ubuntu Asahi can be reported to [UbuntuAsahi/ubuntu-asahi](https://github.com/UbuntuAsahi/ubuntu-asahi/issues). Issues on this website can be reported to [UbuntuAsahi/ubuntuasahi.github.io](https://github.com/UbuntuAsahi/ubuntuasahi.github.io).
+
+Ubuntu Asahi supports Ubuntu releases for nine months ([the duration of an interim release](https://ubuntu.com/about/release-cycle)). Our Asahi Linux upstream rolls out new dependencies often and we recommend using recent releases.
+
+For hardware support see the [Feature Support](https://github.com/AsahiLinux/docs/wiki/Feature-Support) page from Asahi Linux' wiki. Differences between Asahi Linux and Ubuntu Asahi hardware support will be listed on this page.
+
+The best way to support Ubuntu Asahi is to support [Asahi Linux developers](https://asahilinux.org/support/) 💖

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,6 +5,7 @@
       <nav>
         <ul>
           <li><a href="/about" title="About Ubuntu Asahi">About</a></li>
+          <li><a href="/support" title="Ubuntu Asahi Support">Support</a></li>
           <li><a href="/contributing" title="Contributing to Ubuntu Asahi">Contributing</a></li>
           <li><a href="/conduct" title="Ubuntu Asahi's Code of Conduct">Code of Conduct</a></li>
           <li><a href="https://github.com/UbuntuAsahi/ubuntu-asahi" title="Ubuntu Asahi's GitHub">GitHub</a></li>

--- a/static/install
+++ b/static/install
@@ -12,7 +12,6 @@ if true; then
     export VERSION_FLAG=https://cdn.asahilinux.org/installer/latest
     export INSTALLER_BASE=https://cdn.asahilinux.org/installer
     export INSTALLER_DATA=https://tobhe.de/ubuntu/installer_data.json
-    export REPO_BASE=https://files.tobhe.de/ubuntu
 
     #TMP="$(mktemp -d)"
     TMP=/tmp/asahi-install

--- a/static/install
+++ b/static/install
@@ -11,7 +11,7 @@ if true; then
 
     export VERSION_FLAG=https://cdn.asahilinux.org/installer/latest
     export INSTALLER_BASE=https://cdn.asahilinux.org/installer
-    export INSTALLER_DATA=https://tobhe.de/ubuntu/installer_data.json
+    export INSTALLER_DATA=https://ubuntuasahi.org/installer_data.json
 
     #TMP="$(mktemp -d)"
     TMP=/tmp/asahi-install

--- a/static/installer_data.json
+++ b/static/installer_data.json
@@ -59,39 +59,6 @@
 					"image": "disk.img"
 				}
 			]
-		},
-		{
-			"name": "Ubuntu Desktop 22.04 LTS",
-			"default_os_name": "Ubuntu",
-			"boot_object": "m1n1.bin",
-			"next_object": "m1n1/boot.bin",
-			"package": "ubuntu-desktop-22.04-20231022.zip",
-			"supported_fw": ["12.3", "12.3.1", "12.4", "13.3", "13.5"],
-			"partitions": [
-				{
-					"name": "EFI",
-					"type": "EFI",
-					"size": "500MB",
-					"format": "fat",
-					"volume_id": "0x2abf9f91",
-					"copy_firmware": true,
-					"copy_installer_data": true,
-					"source": "esp"
-				},
-				{
-					"name": "Boot",
-					"type": "Linux",
-					"size": "2147483648B",
-					"image": "boot.img"
-				},
-				{
-					"name": "Root",
-					"type": "Linux",
-					"size": "12GB",
-					"expand": true,
-					"image": "root.img"
-				}
-			]
 		}
 	]
 }

--- a/static/installer_data.json
+++ b/static/installer_data.json
@@ -1,0 +1,97 @@
+{
+	"os_list": [
+		{
+			"name": "Ubuntu Desktop 23.10",
+			"default_os_name": "Ubuntu",
+			"boot_object": "m1n1.bin",
+			"next_object": "m1n1/boot.bin",
+			"package": "ubuntu-desktop-23.10-20231107.zip",
+			"supported_fw": ["12.3", "12.3.1", "12.4", "13.3", "13.5"],
+			"partitions": [
+				{
+					"name": "EFI",
+					"type": "EFI",
+					"size": "500MB",
+					"format": "fat",
+					"volume_id": "0x51d3aace",
+					"copy_firmware": true,
+					"copy_installer_data": true,
+					"source": "esp"
+				},
+				{
+					"name": "Boot",
+					"type": "Linux",
+					"size": "2147483648B",
+					"image": "boot.img"
+				},
+				{
+					"name": "Root",
+					"type": "Linux",
+					"size": "12GB",
+					"expand": true,
+					"image": "root.img"
+				}
+			]
+		},
+		{
+			"name": "Ubuntu Desktop 23.04",
+			"default_os_name": "Ubuntu",
+			"boot_object": "m1n1.bin",
+			"next_object": "m1n1/boot.bin",
+			"package": "ubuntu-desktop-23.04-20231012.zip",
+			"supported_fw": ["12.3", "12.3.1", "12.4", "13.3", "13.5"],
+			"partitions": [
+				{
+					"name": "EFI",
+					"type": "EFI",
+					"size": "500MB",
+					"format": "fat",
+					"volume_id": "0x2abf9f91",
+					"copy_firmware": true,
+					"copy_installer_data": true,
+					"source": "esp"
+				},
+				{
+					"name": "Root",
+					"type": "Linux",
+					"size": "12GB",
+					"expand": true,
+					"image": "disk.img"
+				}
+			]
+		},
+		{
+			"name": "Ubuntu Desktop 22.04 LTS",
+			"default_os_name": "Ubuntu",
+			"boot_object": "m1n1.bin",
+			"next_object": "m1n1/boot.bin",
+			"package": "ubuntu-desktop-22.04-20231022.zip",
+			"supported_fw": ["12.3", "12.3.1", "12.4", "13.3", "13.5"],
+			"partitions": [
+				{
+					"name": "EFI",
+					"type": "EFI",
+					"size": "500MB",
+					"format": "fat",
+					"volume_id": "0x2abf9f91",
+					"copy_firmware": true,
+					"copy_installer_data": true,
+					"source": "esp"
+				},
+				{
+					"name": "Boot",
+					"type": "Linux",
+					"size": "2147483648B",
+					"image": "boot.img"
+				},
+				{
+					"name": "Root",
+					"type": "Linux",
+					"size": "12GB",
+					"expand": true,
+					"image": "root.img"
+				}
+			]
+		}
+	]
+}

--- a/static/installer_data.json
+++ b/static/installer_data.json
@@ -32,33 +32,6 @@
 					"image": "root.img"
 				}
 			]
-		},
-		{
-			"name": "Ubuntu Desktop 23.04",
-			"default_os_name": "Ubuntu",
-			"boot_object": "m1n1.bin",
-			"next_object": "m1n1/boot.bin",
-			"package": "ubuntu-desktop-23.04-20231012.zip",
-			"supported_fw": ["12.3", "12.3.1", "12.4", "13.3", "13.5"],
-			"partitions": [
-				{
-					"name": "EFI",
-					"type": "EFI",
-					"size": "500MB",
-					"format": "fat",
-					"volume_id": "0x2abf9f91",
-					"copy_firmware": true,
-					"copy_installer_data": true,
-					"source": "esp"
-				},
-				{
-					"name": "Root",
-					"type": "Linux",
-					"size": "12GB",
-					"expand": true,
-					"image": "disk.img"
-				}
-			]
 		}
 	]
 }


### PR DESCRIPTION
This adds installer_data.json to version control and removes 22.04 as a default option.