### PR TITLE
Move about.html contents to front page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,10 +1,8 @@
 ---
-title: "About"
+title: "Index"
 draft: false
 ---
 
 Ubuntu Asahi is a community project porting Asahi Linux to Ubuntu with the goal of enabling stable and fully featured Ubuntu installs on Apple silicon hardware.
-
-To install Ubuntu Asahi follow steps on our [ubuntu-asahi](https://github.com/UbuntuAsahi/ubuntu-asahi#readme) GitHub page.
 
 If you are interested in the project and would like to get involved feel free to [drop by](/contributing)!

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,8 @@
       </div>
     </div>
     <div class="inner">
-      <p>Installing Ubuntu Asahi is as easy as:</p>
+      {{ .Content }}
+      <h2>Install Ubuntu Asahi from macOS</h2>
       <div id="term">
         <div id="bar">
           <span class="dot red"></span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,6 @@
       <h1><a href="{{ .Site.BaseURL }}" title="{{ .Site.Title }}">Ubuntu Asahi</a></h1>
       <nav>
         <ul>
-          <li><a href="/about" title="About Ubuntu Asahi">About</a></li>
           <li><a href="/support" title="Ubuntu Asahi Support">Support</a></li>
           <li><a href="/contributing" title="Contributing to Ubuntu Asahi">Contributing</a></li>
           <li><a href="/conduct" title="Ubuntu Asahi's Code of Conduct">Code of Conduct</a></li>


### PR DESCRIPTION
I feel like we should answer the question "What is this?" more prominently on our landing page. At the same time we have an "about" section that has very little but a one sentence answer to this question.

This PR moves the content of about to the front page. I also changed the installer text a bit to give the site more structure now that there is more text.

Here's how it looks:

![2024-02-13-233444_886x1120_scrot](https://github.com/UbuntuAsahi/ubuntuasahi.github.io/assets/9573670/ac567c0e-5cf3-4515-8999-480350a22355)