### PR TITLE
Use a dynamic copyright year

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,6 +10,6 @@
       <p>Ubuntu is a trademark of Canonical Ltd. Asahi Linux is a project by The Asahi Linux Contributors. Linux is a Registered Trademark of Linus Torvalds. Ubuntu Asahi is not affiliated with Canonical Ltd or The Asahi Linux Contributors. All other product names, logos, and brands are property of their respective owners.</p>
       <p>Ubuntu name and logo are owned by <a href="https://ubuntu.com/">Canonical Limited</a>. Asahi name used with permission of <a href="https://asahilinux.org/">The Asahi Linux Contributors</a>. Code of Conduct text, hero image, and disclaimer text based on <a href="https://github.com/AsahiLinux">Asahi Linux</a>. Artwork for hero image is distributed under CC BY-SA 4.0. Contribution text based on <a href="https://github.com/atom/atom/blob/master/CONTRIBUTING.md">Atom</a> which is distributed under a MIT License.</p>
       <p>Website generated with <a href="https://gohugo.io/">Hugo</a> and shared on <a href="https://github.com/UbuntuAsahi/ubuntuasahi.github.io">GitHub</a> under a BSD-3-Clause License.</p>
-      <p>Copyright © 2023 Ubuntu Asahi. All rights reserved.</p>
+      <p>Copyright © {{ time.Now.Year }} Ubuntu Asahi. All rights reserved.</p>
     </div>
   </footer>


### PR DESCRIPTION
I noticed the website still mentioned 2023 in the footer. This updates that while always keeping the year current.